### PR TITLE
Feature/10/delete entities

### DIFF
--- a/include/atlas/core/Engine.hpp
+++ b/include/atlas/core/Engine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <print>
 #include <unordered_map>
@@ -86,37 +87,33 @@ auto Engine<G>::run() -> void {
 
     init_status = EngineInitStatus::Initialized;
 
-    auto num_frames = 0;
+    std::uint64_t num_frames = 0;
     while (!game.should_quit()) {
+        if (num_frames == 1) {
+            clock.start_post_first_frame_timer();
+        }
+
         tick_root();
 
-        clock.update_delta_time();
+        clock.update_frame_timers(num_frames);
         num_frames++;
     }
 
-    std::println("Num frames: {}", num_frames);
+    const auto total_time = clock.get_total_time();
+    const auto total_tick_time = *clock.get_total_time_without_first_frame();
+    std::println("\nNum frames: {}", num_frames);
+    std::println("Total runtime: {}", total_time);
+    std::println("First frame: {}", total_time - total_tick_time);
 
-    // const auto path = std::string("perf_stats/no_changes");
-    // std::filesystem::create_directories(path);
-    //
-    // const auto file_count = std::count_if(
-    //     std::filesystem::directory_iterator(path),
-    //     std::filesystem::directory_iterator(),
-    //     [](auto const& entry) {
-    //         return entry.is_regular_file();
-    //     }
-    // );
-    //
-    // const auto file_name = path + "/" + std::to_string(file_count) + ".txt";
-    // {
-    //     std::ofstream ofs(file_name);
-    //     if (!ofs) {
-    //         std::println("Failed to open file: {}", file_name);
-    //     } else {
-    //         ofs << num_frames << "\n";
-    //         std::println("Wrote {} frames to {}", num_frames, file_name);
-    //     }
-    // }
+    std::println(
+        "\navg FPS(excluding first frame): {}",
+        static_cast<double>(num_frames) / total_tick_time
+    );
+    std::println("avg FPS: {}", static_cast<double>(num_frames) / total_time);
+
+    std::println("\navg frame time: {}", clock.get_avg_frame_time());
+    std::println("fastest frame: {}", clock.get_fastest_frame_time());
+    std::println("slowest frame: {}", clock.get_slowest_frame_time());
 }
 
 template <TypeOfGame G>

--- a/include/atlas/core/Engine.hpp
+++ b/include/atlas/core/Engine.hpp
@@ -56,14 +56,10 @@ Engine<G>::~Engine() {
     for (auto& [module_type, module] : modules) {
         module->shutdown();
     }
-
-    std::println("Engine destroyed");
 }
 
 template <TypeOfGame G>
 auto Engine<G>::run() -> void {
-    std::println("Engine::run()");
-
     game.set_engine(*this);
 
     init_status = EngineInitStatus::RunningPreStart;

--- a/include/atlas/core/ITickable.hpp
+++ b/include/atlas/core/ITickable.hpp
@@ -12,7 +12,6 @@ class ITickable {
     auto operator=(ITickable&&) -> ITickable& = delete;
 
     virtual auto tick() -> void = 0;
-    [[nodiscard]] virtual auto get_tick_rate() const -> unsigned = 0;
 
   protected:
     ITickable() = default;

--- a/include/atlas/core/time/EngineClock.hpp
+++ b/include/atlas/core/time/EngineClock.hpp
@@ -1,15 +1,27 @@
 #pragma once
 
+#include <limits>
+#include <optional>
+
 #include "IEngineClock.hpp"
-#include <core/time/Timer.hpp>
+
+#include "core/time/Timer.hpp"
 
 namespace atlas::core {
 class EngineClock final : public IEngineClock {
   public:
-    auto update_delta_time() -> void;
+    auto update_frame_timers(const std::uint64_t& num_frames) -> void;
 
+    [[nodiscard]] auto get_total_time_without_first_frame() const
+        -> std::expected<double, EngineClockErrorCode> override;
     [[nodiscard]] auto get_total_time() const -> double override;
     [[nodiscard]] auto get_delta_time() const -> double override;
+
+    [[nodiscard]] auto get_avg_frame_time() const -> double override;
+    [[nodiscard]] auto get_fastest_frame_time() const -> double override;
+    [[nodiscard]] auto get_slowest_frame_time() const -> double override;
+
+    auto start_post_first_frame_timer() -> void;
 
   private:
     struct DeltaTime {
@@ -18,6 +30,11 @@ class EngineClock final : public IEngineClock {
     };
 
     Timer total_run_time{};
+    std::optional<Timer> run_time_post_first_frame;
     DeltaTime delta_time{};
+
+    double avg_frame_time{0.0};
+    double fastest_frame{std::numeric_limits<double>::max()};
+    double slowest_frame{0.0};
 };
 } // namespace atlas::core

--- a/include/atlas/core/time/IEngineClock.hpp
+++ b/include/atlas/core/time/IEngineClock.hpp
@@ -1,6 +1,15 @@
 #pragma once
 
+#include <cstdint>
+#include <expected>
+
 namespace atlas::core {
+enum class EngineClockErrorCode : std::uint8_t {
+    NoError,
+
+    FirstFrameHasNotFinishedOrTimerNotStarted
+};
+
 class IEngineClock {
   public:
     virtual ~IEngineClock() = default;
@@ -11,8 +20,14 @@ class IEngineClock {
     IEngineClock(IEngineClock&&) = delete;
     auto operator=(IEngineClock&&) -> IEngineClock& = delete;
 
+    [[nodiscard]] virtual auto get_total_time_without_first_frame() const
+        -> std::expected<double, EngineClockErrorCode> = 0;
     [[nodiscard]] virtual auto get_total_time() const -> double = 0;
     [[nodiscard]] virtual auto get_delta_time() const -> double = 0;
+
+    [[nodiscard]] virtual auto get_avg_frame_time() const -> double = 0;
+    [[nodiscard]] virtual auto get_fastest_frame_time() const -> double = 0;
+    [[nodiscard]] virtual auto get_slowest_frame_time() const -> double = 0;
 
   protected:
     IEngineClock() = default;

--- a/modules/hephaestus/CMakeLists.txt
+++ b/modules/hephaestus/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_include_directories(atlas PUBLIC include)
-target_sources(atlas PRIVATE src/hephaestus/Hephaestus.cpp
-                             src/hephaestus/Utils.cpp)
+target_sources(
+  atlas PRIVATE src/hephaestus/Hephaestus.cpp src/hephaestus/Archetype.cpp
+                src/hephaestus/Utils.cpp)

--- a/modules/hephaestus/include/hephaestus/Archetype.hpp
+++ b/modules/hephaestus/include/hephaestus/Archetype.hpp
@@ -50,10 +50,10 @@ struct ComponentStorage final : public IComponentStorage {
 class Archetype final {
   public:
     Archetype() {
-        constexpr auto ENTITY_BUFFERT = 500;
-        ent_to_component_index.reserve(ENTITY_BUFFERT);
-        component_index_to_ent.reserve(ENTITY_BUFFERT);
-        component_storages.reserve(ENTITY_BUFFERT);
+        constexpr auto ENTITY_BUFFER = 500;
+        ent_to_component_index.reserve(ENTITY_BUFFER);
+        component_index_to_ent.reserve(ENTITY_BUFFER);
+        component_storages.reserve(ENTITY_BUFFER);
     }
 
     virtual ~Archetype() = default;

--- a/modules/hephaestus/include/hephaestus/Archetype.hpp
+++ b/modules/hephaestus/include/hephaestus/Archetype.hpp
@@ -42,6 +42,7 @@ struct ComponentStorage final : public IComponentStorage {
         }
 
         components.pop_back();
+        ComponentType::increment_version();
     }
 
     std::vector<ComponentType> components{};
@@ -90,9 +91,8 @@ auto Archetype::create_entity(Entity entity, ComponentTypes&&... components) -> 
     (add_to_component_storage<ComponentTypes>(std::forward<ComponentTypes>(components)), ...);
     assert(!component_storages.empty() && "Cannot add entity without components");
 
-    const auto& component_storage = *component_storages.begin()->second;
-    const auto size = component_storage.size();
-    ent_to_component_index.emplace(entity, size);
+    const auto& first_component_storage = *component_storages.begin()->second;
+    ent_to_component_index.emplace(entity, first_component_storage.size() - 1);
     component_index_to_ent.emplace_back(entity);
 }
 
@@ -123,6 +123,6 @@ auto Archetype::add_to_component_storage(ComponentType&& component) -> void {
     static_cast<ComponentStorage<ComponentType>&>(*component_storages[type_id].get())
         .components.emplace_back(std::forward<ComponentType>(component));
 
-    ComponentType::version_counter++;
+    ComponentType::increment_version();
 }
 } // namespace atlas::hephaestus

--- a/modules/hephaestus/include/hephaestus/ArchetypeKey.hpp
+++ b/modules/hephaestus/include/hephaestus/ArchetypeKey.hpp
@@ -17,7 +17,7 @@ namespace atlas::hephaestus {
 // it be controlled from the Game space.
 class ArchetypeKey {
   public:
-    static constexpr size_t STORAGE_SIZE = 4;
+    static constexpr std::size_t STORAGE_SIZE = 4;
     using ValueType = std::uint64_t;
     using StorageType = std::array<ValueType, STORAGE_SIZE>;
 
@@ -48,14 +48,14 @@ class ArchetypeKey {
     }
 
     [[nodiscard]] constexpr auto has_component(size_t component_id) const -> bool {
-        const size_t bucket = component_id / 64;
-        const size_t bit = component_id % 64;
+        const std::size_t bucket = component_id / 64;
+        const std::size_t bit = component_id % 64;
         return bucket < STORAGE_SIZE && (storage.at(bucket) & (1ULL << bit)) != 0;
     }
 
     constexpr auto add_component(size_t component_id) -> ArchetypeKey& {
-        const size_t bucket = component_id / 64;
-        const size_t bit = component_id % 64;
+        const std::size_t bucket = component_id / 64;
+        const std::size_t bit = component_id % 64;
         if (bucket < STORAGE_SIZE) {
             storage.at(bucket) |= (1ULL << bit);
         }
@@ -98,14 +98,14 @@ class ArchetypeKey {
     StorageType storage{};
 };
 
-constexpr auto next_id() -> size_t {
-    static size_t id = 0;
+constexpr auto next_id() -> std::size_t {
+    static std::size_t id = 0;
     return id++;
 }
 
 template <typename T>
-constexpr auto counter() -> size_t {
-    static size_t value = next_id();
+constexpr auto counter() -> std::size_t {
+    static std::size_t value = next_id();
     return value;
 }
 

--- a/modules/hephaestus/include/hephaestus/ArchetypeKey.hpp
+++ b/modules/hephaestus/include/hephaestus/ArchetypeKey.hpp
@@ -138,7 +138,7 @@ struct ArchetypeKeyHash {
         // Combine all storage buckets into a single hash
         std::size_t result = 0;
         const auto& storage = sig.get_storage();
-        for (size_t i = 0; i < ArchetypeKey::STORAGE_SIZE; ++i) {
+        for (std::size_t i = 0; i < ArchetypeKey::STORAGE_SIZE; ++i) {
             // Use a simple hash combining algorithm
             result ^= std::hash<std::uint64_t>{}(storage.at(i)) + 0x9e3779b9
                       + (result << std::size_t{6}) + (result >> std::size_t{2});

--- a/modules/hephaestus/include/hephaestus/ArchetypeKey.hpp
+++ b/modules/hephaestus/include/hephaestus/ArchetypeKey.hpp
@@ -98,6 +98,17 @@ class ArchetypeKey {
     StorageType storage{};
 };
 
+constexpr auto next_id() -> size_t {
+    static size_t id = 0;
+    return id++;
+}
+
+template <typename T>
+constexpr auto counter() -> size_t {
+    static size_t value = next_id();
+    return value;
+}
+
 // Simple compile-time string hash using FNV-1a algorithm
 constexpr auto hash_string(std::string_view str) -> std::uint64_t {
     std::uint64_t hash = 14695981039346656037ULL; // FNV offset basis
@@ -109,13 +120,13 @@ constexpr auto hash_string(std::string_view str) -> std::uint64_t {
 }
 
 template <typename T>
-inline auto get_component_type_id() -> size_t {
+constexpr auto get_component_type_id() -> std::size_t {
     // Normalize the type to remove cv-qualifiers and references
     using NormalizedType = std::remove_cvref_t<T>;
 
     // Use a type-specific approach that works with normalized types
     // This ensures const Position and Position get the same ID
-    const auto hash = hash_string(typeid(NormalizedType).name());
+    const auto hash = counter<NormalizedType>();
 
     // Ensure we stay within our storage capacity
     return hash % (ArchetypeKey::STORAGE_SIZE * 64);

--- a/modules/hephaestus/include/hephaestus/Component.hpp
+++ b/modules/hephaestus/include/hephaestus/Component.hpp
@@ -17,8 +17,11 @@ class Component {
         return version_counter;
     }
 
+    static auto increment_version() -> void {
+        version_counter++;
+    }
+
   private:
-    friend class Archetype;
     static std::uint64_t version_counter;
 };
 

--- a/modules/hephaestus/include/hephaestus/Concepts.hpp
+++ b/modules/hephaestus/include/hephaestus/Concepts.hpp
@@ -15,7 +15,4 @@ concept TypeOfComponent = std::
 
 template <typename... Ts>
 concept AllTypeOfComponent = (TypeOfComponent<Ts> && ...);
-
-template <typename T>
-concept RValueArg = !std::is_lvalue_reference_v<T>;
 } // namespace atlas::hephaestus

--- a/modules/hephaestus/include/hephaestus/Hashing.hpp
+++ b/modules/hephaestus/include/hephaestus/Hashing.hpp
@@ -9,8 +9,8 @@ namespace atlas::hephaestus {
 struct TypeIndexVectorHash {
     auto operator()(const std::vector<std::type_index>& types) const -> std::size_t {
         std::size_t seed = 0;
-        constexpr size_t LEFT_SHIFT = 6;
-        constexpr size_t RIGHT_SHIFT = 2;
+        constexpr std::size_t LEFT_SHIFT = 6;
+        constexpr std::size_t RIGHT_SHIFT = 2;
         for (const auto& type : types) {
             seed ^= type.hash_code() + GOLDEN_RATIO_32 + (seed << LEFT_SHIFT)
                     + (seed >> RIGHT_SHIFT);

--- a/modules/hephaestus/include/hephaestus/Hephaestus.hpp
+++ b/modules/hephaestus/include/hephaestus/Hephaestus.hpp
@@ -40,7 +40,6 @@ class Hephaestus final : public core::Module, public core::ITickable {
     auto shutdown() -> void override;
 
     auto tick() -> void override;
-    [[nodiscard]] auto get_tick_rate() const -> unsigned override;
 
     template <typename Func>
     auto create_system(Func&& func) -> void;

--- a/modules/hephaestus/include/hephaestus/Hephaestus.hpp
+++ b/modules/hephaestus/include/hephaestus/Hephaestus.hpp
@@ -123,7 +123,7 @@ template <typename Func>
 auto Hephaestus::create_system(Func&& func) -> void {
     const auto init_status = get_engine().get_engine_init_status();
     assert(
-        init_status == core::EngineInitStatus::RunningStart
+        init_status <= core::EngineInitStatus::RunningStart
         && "Cannot create systems after startup."
     );
     assert(

--- a/modules/hephaestus/include/hephaestus/Hephaestus.hpp
+++ b/modules/hephaestus/include/hephaestus/Hephaestus.hpp
@@ -49,6 +49,9 @@ class Hephaestus final : public core::Module, public core::ITickable {
 
     auto destroy_entity(Entity entity) -> void;
 
+    auto get_tot_num_created_ents() const -> std::uint64_t;
+    auto get_tot_num_destroyed_ents() const -> std::uint64_t;
+
   protected:
     [[nodiscard]] static auto generate_unique_entity_id() -> Entity;
 
@@ -66,8 +69,8 @@ class Hephaestus final : public core::Module, public core::ITickable {
     tf::Taskflow systems_graph;
     tf::Executor systems_executor;
 
-    std::size_t tot_num_created_ents = 0;
-    std::size_t tot_num_destroyed_ents = 0;
+    std::uint64_t tot_num_created_ents = 0;
+    std::uint64_t tot_num_destroyed_ents = 0;
 
     // This is all confusing, however, the purpose of this is to improve the API
     // for calling the create_system function. This way, the user only needs to

--- a/modules/hephaestus/include/hephaestus/Hephaestus.hpp
+++ b/modules/hephaestus/include/hephaestus/Hephaestus.hpp
@@ -11,6 +11,7 @@
 #include "core/ITickable.hpp"
 #include "core/Module.hpp"
 #include "hephaestus/Archetype.hpp"
+#include "hephaestus/ArchetypeKey.hpp"
 #include "hephaestus/ArchetypeMap.hpp"
 #include "hephaestus/Common.hpp"
 #include "hephaestus/Concepts.hpp"
@@ -47,6 +48,8 @@ class Hephaestus final : public core::Module, public core::ITickable {
     template <AllTypeOfComponent... ComponentTypes>
     auto create_entity(ComponentTypes&&... components) -> void;
 
+    auto destroy_entity(Entity entity) -> void;
+
   protected:
     [[nodiscard]] static auto generate_unique_entity_id() -> Entity;
 
@@ -55,6 +58,7 @@ class Hephaestus final : public core::Module, public core::ITickable {
   private:
     std::vector<std::unique_ptr<SystemBase>> systems;
     ArchetypeMap archetypes;
+    std::unordered_map<Entity, ArchetypeKey> ent_to_archetype_key;
 
     std::vector<std::function<void()>> creation_queue;
     std::vector<std::function<void()>> destroy_queue;
@@ -172,6 +176,8 @@ auto Hephaestus::create_entity(ComponentTypes&&... components) -> void {
             },
             data
         );
+
+        ent_to_archetype_key.emplace(entity_id, signature);
     });
 }
 } // namespace atlas::hephaestus

--- a/modules/hephaestus/include/hephaestus/Hephaestus.hpp
+++ b/modules/hephaestus/include/hephaestus/Hephaestus.hpp
@@ -67,6 +67,9 @@ class Hephaestus final : public core::Module, public core::ITickable {
     tf::Taskflow systems_graph;
     tf::Executor systems_executor;
 
+    std::size_t tot_num_created_ents = 0;
+    std::size_t tot_num_destroyed_ents = 0;
+
     // This is all confusing, however, the purpose of this is to improve the API
     // for calling the create_system function. This way, the user only needs to
     // pass the lambda which will be used as the system function, the rest is

--- a/modules/hephaestus/include/hephaestus/Hephaestus.hpp
+++ b/modules/hephaestus/include/hephaestus/Hephaestus.hpp
@@ -61,7 +61,7 @@ class Hephaestus final : public core::Module, public core::ITickable {
     std::unordered_map<Entity, ArchetypeKey> ent_to_archetype_key;
 
     std::vector<std::function<void()>> creation_queue;
-    std::vector<std::function<void()>> destroy_queue;
+    std::vector<Entity> destroy_queue;
     std::optional<std::vector<SystemNode>> system_nodes = std::vector<SystemNode>{};
 
     tf::Taskflow systems_graph;

--- a/modules/hephaestus/include/hephaestus/query/ArchetypeQueryContext.hpp
+++ b/modules/hephaestus/include/hephaestus/query/ArchetypeQueryContext.hpp
@@ -2,7 +2,6 @@
 
 #include "hephaestus/ArchetypeMap.hpp"
 #include "hephaestus/Utils.hpp"
-#include <print>
 
 namespace atlas::hephaestus {
 struct ArchetypeQueryContext final {
@@ -11,10 +10,7 @@ struct ArchetypeQueryContext final {
         std::vector<SystemDependencies> dependencies
     )
         : archetypes{archetypes}
-        , dependencies{std::move(dependencies)} {
-
-        std::println("QueryContext Constructor");
-    }
+        , dependencies{std::move(dependencies)} {}
 
     ArchetypeQueryContext(const ArchetypeQueryContext&) = delete;
     auto operator=(const ArchetypeQueryContext&) -> ArchetypeQueryContext& = delete;

--- a/modules/hephaestus/include/hephaestus/query/Query.hpp
+++ b/modules/hephaestus/include/hephaestus/query/Query.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iterator>
 #include <optional>
 #include <print>
 

--- a/modules/hephaestus/include/hephaestus/query/Query.hpp
+++ b/modules/hephaestus/include/hephaestus/query/Query.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <optional>
-#include <print>
 
 #include "hephaestus/ArchetypeMap.hpp"
 #include "hephaestus/Concepts.hpp"
@@ -13,9 +12,7 @@ template <AllTypeOfComponent... ComponentTypes>
 class Query final {
   public:
     Query(const ArchetypeMap& archetypes, std::vector<SystemDependencies> dependencies)
-        : context{archetypes, std::move(dependencies)} {
-        std::println("Query Constructor");
-    }
+        : context{archetypes, std::move(dependencies)} {}
 
     Query(const Query&) = delete;
     auto operator=(const Query&) = delete;

--- a/modules/hephaestus/src/hephaestus/Archetype.cpp
+++ b/modules/hephaestus/src/hephaestus/Archetype.cpp
@@ -22,6 +22,7 @@ auto Archetype::destroy_entity(Entity entity) -> bool {
 
     ent_to_component_index.erase(entity);
     component_index_to_ent.pop_back();
+
     return true;
 }
 } // namespace atlas::hephaestus

--- a/modules/hephaestus/src/hephaestus/Archetype.cpp
+++ b/modules/hephaestus/src/hephaestus/Archetype.cpp
@@ -1,0 +1,27 @@
+#include "hephaestus/Archetype.hpp"
+
+namespace atlas::hephaestus {
+auto Archetype::destroy_entity(Entity entity) -> bool {
+    assert(ent_to_component_index.contains(entity) && "Entity does not exist in archetype");
+    if (!ent_to_component_index.contains(entity)) {
+        return false;
+    }
+
+    const auto last_component_index = component_storages.begin()->second->size() - 1;
+    const auto entity_at_back = component_index_to_ent.at(last_component_index);
+
+    const auto component_index_for_entity = ent_to_component_index.at(entity);
+    for (auto& [component_type_id, storage_ptr] : component_storages) {
+        (*storage_ptr).destroy(component_index_for_entity);
+    }
+
+    if (entity != entity_at_back) {
+        ent_to_component_index[entity_at_back] = component_index_for_entity;
+        component_index_to_ent[component_index_for_entity] = entity_at_back;
+    }
+
+    ent_to_component_index.erase(entity);
+    component_index_to_ent.pop_back();
+    return true;
+}
+} // namespace atlas::hephaestus

--- a/modules/hephaestus/src/hephaestus/Hephaestus.cpp
+++ b/modules/hephaestus/src/hephaestus/Hephaestus.cpp
@@ -22,19 +22,15 @@ Hephaestus::Hephaestus(core::IEngine& engine)
     constexpr auto QUEUE_BUFFER = 100;
     creation_queue.reserve(QUEUE_BUFFER);
     destroy_queue.reserve(QUEUE_BUFFER);
-    std::println("Hephaestus Constructor");
 }
 
-auto Hephaestus::start() -> void {
-    std::println("Hephaestus::start()");
-}
+auto Hephaestus::start() -> void {}
 
 auto Hephaestus::post_start() -> void {
     build_systems_dependency_graph();
 }
 
 auto Hephaestus::shutdown() -> void {
-    std::println("Hephaestus::shutdown()");
     std::println("\nTotal created ents: {}", tot_num_created_ents);
     std::println("Total destroyed ents: {}", tot_num_destroyed_ents);
 }
@@ -61,11 +57,8 @@ auto Hephaestus::tick() -> void {
             ent_to_archetype_key.erase(entity);
         }
     }
+    tot_num_destroyed_ents += destroy_queue.size();
     destroy_queue.clear();
-}
-
-auto Hephaestus::get_tick_rate() const -> unsigned {
-    return 1;
 }
 
 auto Hephaestus::generate_unique_entity_id() -> Entity {

--- a/modules/hephaestus/src/hephaestus/Hephaestus.cpp
+++ b/modules/hephaestus/src/hephaestus/Hephaestus.cpp
@@ -132,4 +132,12 @@ auto Hephaestus::build_systems_dependency_graph() -> void {
 auto Hephaestus::destroy_entity(Entity entity) -> void {
     destroy_queue.emplace_back(entity);
 }
+
+auto Hephaestus::get_tot_num_created_ents() const -> std::size_t {
+    return tot_num_created_ents;
+}
+
+auto Hephaestus::get_tot_num_destroyed_ents() const -> std::size_t {
+    return tot_num_destroyed_ents;
+}
 } // namespace atlas::hephaestus

--- a/modules/hephaestus/src/hephaestus/Hephaestus.cpp
+++ b/modules/hephaestus/src/hephaestus/Hephaestus.cpp
@@ -74,7 +74,7 @@ auto Hephaestus::build_systems_dependency_graph() -> void {
     std::vector<std::vector<std::size_t>> system_deps(num_nodes);
     // Very pessimistic guesswork for inner vector capacity, but safe.
     // Choose a more realistic number if needed.
-    for (size_t i = 0; i < num_nodes; ++i) {
+    for (std::size_t i = 0; i < num_nodes; ++i) {
         system_deps[i].reserve(num_nodes);
     }
 
@@ -88,10 +88,10 @@ auto Hephaestus::build_systems_dependency_graph() -> void {
         return are_dependencies_overlapping(node.dependencies, other.dependencies);
     };
 
-    for (size_t i = 0; i < num_nodes; ++i) {
+    for (std::size_t i = 0; i < num_nodes; ++i) {
         auto& node = (*system_nodes)[i];
 
-        for (size_t j = i + 1; j < num_nodes; ++j) {
+        for (std::size_t j = i + 1; j < num_nodes; ++j) {
             auto& other = (*system_nodes)[j];
 
             if (are_nodes_conflicting(node, other)) {

--- a/modules/hephaestus/src/hephaestus/Hephaestus.cpp
+++ b/modules/hephaestus/src/hephaestus/Hephaestus.cpp
@@ -14,6 +14,11 @@ Hephaestus::Hephaestus(core::IEngine& engine)
     // This is OK for now, but we should handle this in a centralized way
     // later on to make sure that we don't have too many threads.
     systems_executor(std::thread::hardware_concurrency()) {
+
+    constexpr auto ARCHETYPE_BUFFERT = 30;
+    archetypes.reserve(ARCHETYPE_BUFFERT);
+    ent_to_archetype_key.reserve(ARCHETYPE_BUFFERT);
+
     constexpr auto QUEUE_BUFFERT = 100;
     creation_queue.reserve(QUEUE_BUFFERT);
     destroy_queue.reserve(QUEUE_BUFFERT);
@@ -103,18 +108,22 @@ auto Hephaestus::build_systems_dependency_graph() -> void {
     }
 
     std::vector<tf::Task> tasks(num_nodes);
-    for (size_t i = 0; i < num_nodes; ++i) {
+    for (std::size_t i = 0; i < num_nodes; ++i) {
         tasks[i] = systems_graph.emplace([this, i](tf::Subflow& subflow) {
             systems[i]->execute(get_engine(), subflow);
         });
     }
 
-    for (size_t i = 0; i < num_nodes; ++i) {
-        for (size_t j : system_deps[i]) {
+    for (std::size_t i = 0; i < num_nodes; ++i) {
+        for (std::size_t j : system_deps[i]) {
             if (i < j) {
                 tasks[i].precede(tasks[j]);
             }
         }
     }
+}
+
+auto Hephaestus::destroy_entity(Entity entity) -> void {
+    //
 }
 } // namespace atlas::hephaestus

--- a/modules/hephaestus/src/hephaestus/Hephaestus.cpp
+++ b/modules/hephaestus/src/hephaestus/Hephaestus.cpp
@@ -15,13 +15,13 @@ Hephaestus::Hephaestus(core::IEngine& engine)
     // later on to make sure that we don't have too many threads.
     systems_executor(std::thread::hardware_concurrency()) {
 
-    constexpr auto ARCHETYPE_BUFFERT = 30;
-    archetypes.reserve(ARCHETYPE_BUFFERT);
-    ent_to_archetype_key.reserve(ARCHETYPE_BUFFERT);
+    constexpr auto ARCHETYPE_BUFFER = 30;
+    archetypes.reserve(ARCHETYPE_BUFFER);
+    ent_to_archetype_key.reserve(ARCHETYPE_BUFFER);
 
-    constexpr auto QUEUE_BUFFERT = 100;
-    creation_queue.reserve(QUEUE_BUFFERT);
-    destroy_queue.reserve(QUEUE_BUFFERT);
+    constexpr auto QUEUE_BUFFER = 100;
+    creation_queue.reserve(QUEUE_BUFFER);
+    destroy_queue.reserve(QUEUE_BUFFER);
     std::println("Hephaestus Constructor");
 }
 

--- a/modules/hephaestus/src/hephaestus/Hephaestus.cpp
+++ b/modules/hephaestus/src/hephaestus/Hephaestus.cpp
@@ -47,10 +47,20 @@ auto Hephaestus::tick() -> void {
         systems_executor.run(systems_graph).wait();
     }
 
-    //
-    // TODO:
-    // Destroy queued entities
+    for (const auto entity : destroy_queue) {
+        assert(
+            ent_to_archetype_key.contains(entity)
+            && "Trying to destroy an entity that doesnt exist!"
+        );
+
+        auto& archetype = *archetypes.at(ent_to_archetype_key.at(entity));
+        if (archetype.destroy_entity(entity)) {
+            ent_to_archetype_key.erase(entity);
+        }
+    }
+    destroy_queue.clear();
 }
+
 auto Hephaestus::get_tick_rate() const -> unsigned {
     return 1;
 }
@@ -124,6 +134,6 @@ auto Hephaestus::build_systems_dependency_graph() -> void {
 }
 
 auto Hephaestus::destroy_entity(Entity entity) -> void {
-    //
+    destroy_queue.emplace_back(entity);
 }
 } // namespace atlas::hephaestus

--- a/modules/hephaestus/src/hephaestus/Hephaestus.cpp
+++ b/modules/hephaestus/src/hephaestus/Hephaestus.cpp
@@ -35,12 +35,15 @@ auto Hephaestus::post_start() -> void {
 
 auto Hephaestus::shutdown() -> void {
     std::println("Hephaestus::shutdown()");
+    std::println("\nTotal created ents: {}", tot_num_created_ents);
+    std::println("Total destroyed ents: {}", tot_num_destroyed_ents);
 }
 
 auto Hephaestus::tick() -> void {
     for (auto& creation : creation_queue) {
         creation();
     }
+    tot_num_created_ents += creation_queue.size();
     creation_queue.clear();
 
     if (!systems_graph.empty()) {

--- a/modules/hephaestus/src/hephaestus/Utils.cpp
+++ b/modules/hephaestus/src/hephaestus/Utils.cpp
@@ -5,8 +5,8 @@ auto are_dependencies_overlapping(
     const std::vector<SystemDependencies>& lhs,
     const std::vector<SystemDependencies>& rhs
 ) -> bool {
-    size_t lhs_idx = 0;
-    size_t rhs_idx = 0;
+    std::size_t lhs_idx = 0;
+    std::size_t rhs_idx = 0;
 
     while (lhs_idx < lhs.size() && rhs_idx < rhs.size()) {
         const auto& lhs_access = lhs[lhs_idx];

--- a/src/atlas/core/time/EngineClock.cpp
+++ b/src/atlas/core/time/EngineClock.cpp
@@ -1,9 +1,32 @@
 #include "core/time/EngineClock.hpp"
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <print>
 
 namespace atlas::core {
-auto EngineClock::update_delta_time() -> void {
+auto EngineClock::update_frame_timers(const std::uint64_t& num_frames) -> void {
     delta_time.previous_time = delta_time.frame_timer.elapsed();
     delta_time.frame_timer.reset();
+
+    if (run_time_post_first_frame.has_value()) {
+        if (delta_time.previous_time > 0.002) { // 2ms
+            std::println("⚠️ Frame spike: {} ms", delta_time.previous_time * 1000);
+        }
+
+        avg_frame_time = (*run_time_post_first_frame).elapsed() / static_cast<double>(num_frames);
+        fastest_frame = std::min(delta_time.previous_time, fastest_frame);
+        slowest_frame = std::max(delta_time.previous_time, slowest_frame);
+    }
+}
+
+auto EngineClock::get_total_time_without_first_frame() const
+    -> std::expected<double, EngineClockErrorCode> {
+    if (run_time_post_first_frame.has_value()) {
+        return (*run_time_post_first_frame).elapsed();
+    }
+
+    return std::unexpected(EngineClockErrorCode::FirstFrameHasNotFinishedOrTimerNotStarted);
 }
 
 auto EngineClock::get_total_time() const -> double {
@@ -12,5 +35,26 @@ auto EngineClock::get_total_time() const -> double {
 
 auto EngineClock::get_delta_time() const -> double {
     return delta_time.previous_time;
+}
+
+auto EngineClock::get_avg_frame_time() const -> double {
+    return avg_frame_time;
+}
+
+auto EngineClock::get_fastest_frame_time() const -> double {
+    return fastest_frame;
+}
+
+auto EngineClock::get_slowest_frame_time() const -> double {
+    return slowest_frame;
+}
+
+auto EngineClock::start_post_first_frame_timer() -> void {
+    assert(
+        !run_time_post_first_frame.has_value()
+        && "Trying to start post first frame timer which is already started"
+    );
+
+    run_time_post_first_frame = Timer{};
 }
 } // namespace atlas::core

--- a/tests/HephaestusTests.cpp
+++ b/tests/HephaestusTests.cpp
@@ -15,18 +15,18 @@ using namespace atlas;
 using namespace atlas::core;
 using namespace atlas::hephaestus;
 
-// Simple test components
 struct Position : public Component<Position> {
     float x, y;
 };
+
 struct Velocity : public Component<Velocity> {
     float dx, dy;
 };
+
 struct Health : public Component<Health> {
     int value;
 };
 
-// Global test state
 struct TestState {
     int physics_runs = 0;
     int renderer_runs = 0;
@@ -37,84 +37,84 @@ struct TestState {
 // clang-tidy rightfuly complains about this, however, it's fine for the test case.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static TestState* TEST_STATE = nullptr;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static bool USE_SHOULD_STOP = false;
 
-// Mock game class for testing
-class TestGame : public IGame {
+class MockGame : public IGame {
   public:
+    auto stop_game() -> void {
+        should_stop = true;
+    }
+
     auto pre_start() -> void override {}
+
     auto start() -> void override {
         auto& hephaestus = engine_ptr->get_module<Hephaestus>().get();
 
-        // Create some entities first
         hephaestus.create_entity(Position{.x = 1.F, .y = 2.F}, Velocity{.dx = 0.5F, .dy = -0.5F});
         hephaestus.create_entity(Position{.x = 3.F, .y = 4.F}, Velocity{.dx = 1.F, .dy = 1.F});
         hephaestus.create_entity(Position{.x = 5.F, .y = 6.F}, Health{.value = 100});
 
         if (TEST_STATE != nullptr) {
-            // Create a physics system (writes to Position, reads Velocity)
             hephaestus.create_system([](const IEngine& engine,
                                         std::tuple<Position&, const Velocity&> components) {
                 auto& [pos, vel] = components;
-                pos.x += vel.dx * 0.1F; // Small delta for testing
+                pos.x += vel.dx * 0.1F;
                 pos.y += vel.dy * 0.1F;
                 TEST_STATE->physics_runs++;
             });
 
-            // Create a renderer system (reads Position and Velocity)
             hephaestus.create_system([](const IEngine& engine,
                                         std::tuple<const Position&, const Velocity&> components) {
                 const auto& [pos, vel] = components;
-                // Simulate rendering
                 TEST_STATE->renderer_runs++;
             });
 
-            // Create a health checker system (reads Health)
             hephaestus.create_system([](const IEngine& engine,
                                         std::tuple<const Health&> components) {
                 const auto& [health] = components;
-                // Simulate health checking
                 TEST_STATE->health_checker_runs++;
             });
         }
     }
+
     auto post_start() -> void override {
-        // After everything is set up, prepare to quit after a few frames
         start_time = std::chrono::steady_clock::now();
     }
+
     auto pre_shutdown() -> void override {}
     auto shutdown() -> void override {}
     auto post_shutdown() -> void override {}
+
     [[nodiscard]] auto get_engine() const -> IEngine& override {
         return *engine_ptr;
     }
+
     auto set_engine(IEngine& engine_ref) -> void override {
         engine_ptr = &engine_ref;
     }
+
     [[nodiscard]] auto should_quit() const -> bool override {
-        // Quit after a short time to let a few frames run
-        if (start_time.time_since_epoch().count() == 0) {
-            return false; // Not started yet
+        if (USE_SHOULD_STOP) {
+            return should_stop;
         }
+
+        if (start_time.time_since_epoch().count() == 0) {
+            return false;
+        }
+
         auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time);
-        return elapsed.count() > 100; // Quit after 100ms
+        return elapsed.count() > 40;
     }
 
   private:
     IEngine* engine_ptr = nullptr;
     std::chrono::steady_clock::time_point start_time;
+    bool should_stop = false;
 };
 
-// Utility function tests (don't require full engine)
-class HephaestusUtilsTest : public ::testing::Test {
-  protected:
-    void SetUp() override {}
-    void TearDown() override {}
-};
-
-// Test 1: Basic const dependency generation
-TEST_F(HephaestusUtilsTest, SystemDependenciesGeneration) {
-    // Test basic const detection
+TEST(HephaestusTest, SystemDependenciesGeneration) {
     auto const_signature = make_system_dependencies<const Position&, const Velocity&>();
     EXPECT_EQ(const_signature.size(), 2);
     EXPECT_TRUE(const_signature[0].is_read_only);
@@ -138,28 +138,42 @@ TEST_F(HephaestusUtilsTest, SystemDependenciesGeneration) {
     EXPECT_FALSE(vel_it->is_read_only); // Velocity&
 }
 
-// Test 2: Const-aware conflict detection
-TEST_F(HephaestusUtilsTest, ConstAwareConflictDetection) {
-    // Two read-only systems should NOT conflict
+TEST(HephaestusTest, SystemConflictDetection) {
     auto read_only_1 = make_system_dependencies<const Position&, const Velocity&>();
     auto read_only_2 = make_system_dependencies<const Position&>();
     EXPECT_FALSE(are_dependencies_overlapping(read_only_1, read_only_2));
 
-    // Read-only vs write should conflict
     auto write_pos = make_system_dependencies<Position&, const Velocity&>();
     EXPECT_TRUE(are_dependencies_overlapping(read_only_1, write_pos));
 
-    // Non-overlapping components should not conflict
     auto health_reader = make_system_dependencies<const Health&>();
     EXPECT_FALSE(are_dependencies_overlapping(read_only_1, health_reader));
+
+    auto empty_access = make_system_dependencies<>();
+    EXPECT_TRUE(empty_access.empty());
+
+    auto pos_sig = make_system_dependencies<const Position&>();
+    EXPECT_FALSE(are_dependencies_overlapping(empty_access, pos_sig));
+    EXPECT_FALSE(are_dependencies_overlapping(pos_sig, empty_access));
+
+    auto audio_sig = make_system_dependencies<const Position&>();
+    auto ui_sig = make_system_dependencies<const Position&, const Velocity&>();
+    auto logger_sig = make_system_dependencies<const Position&>();
+
+    EXPECT_FALSE(are_dependencies_overlapping(audio_sig, ui_sig));
+    EXPECT_FALSE(are_dependencies_overlapping(audio_sig, logger_sig));
+    EXPECT_FALSE(are_dependencies_overlapping(ui_sig, logger_sig));
+
+    auto physics_sig = make_system_dependencies<Position&, const Velocity&>();
+    EXPECT_TRUE(are_dependencies_overlapping(audio_sig, physics_sig));
+    EXPECT_TRUE(are_dependencies_overlapping(ui_sig, physics_sig));
+    EXPECT_TRUE(are_dependencies_overlapping(logger_sig, physics_sig));
 }
 
-// Test 3: Type signature generation (for archetype queries)
-TEST_F(HephaestusUtilsTest, TypeSignatureGeneration) {
+TEST(HephaestusTest, TypeSignatureGeneration) {
     auto signature = make_archetype_key<Position, Velocity>();
     EXPECT_EQ(signature.count_components(), 2);
 
-    // Test that the signature has the expected components
     auto pos_id = get_component_type_id<Position>();
     auto vel_id = get_component_type_id<Velocity>();
 
@@ -167,153 +181,91 @@ TEST_F(HephaestusUtilsTest, TypeSignatureGeneration) {
     EXPECT_TRUE(signature.has_component(vel_id));
 }
 
-// Test 4: Edge cases
-TEST_F(HephaestusUtilsTest, EdgeCases) {
-    // Test empty access signature
-    auto empty_access = make_system_dependencies<>();
-    EXPECT_TRUE(empty_access.empty());
-
-    // Test empty type signature
-    auto empty_type = make_archetype_key<>();
-    EXPECT_TRUE(empty_type.empty());
-
-    // Test overlap with empty signatures
-    auto pos_sig = make_system_dependencies<const Position&>();
-    EXPECT_FALSE(are_dependencies_overlapping(empty_access, pos_sig));
-    EXPECT_FALSE(are_dependencies_overlapping(pos_sig, empty_access));
-}
-
-TEST_F(HephaestusUtilsTest, ParallelExecutionBenefits) {
-    // Create multiple read-only systems that should be able to run in parallel
-    auto audio_sig = make_system_dependencies<const Position&>();
-    auto ui_sig = make_system_dependencies<const Position&, const Velocity&>();
-    auto logger_sig = make_system_dependencies<const Position&>();
-
-    // The key benefit: these systems' signatures should not conflict
-    EXPECT_FALSE(are_dependencies_overlapping(audio_sig, ui_sig));
-    EXPECT_FALSE(are_dependencies_overlapping(audio_sig, logger_sig));
-    EXPECT_FALSE(are_dependencies_overlapping(ui_sig, logger_sig));
-
-    // But a write system should conflict with them
-    auto physics_sig = make_system_dependencies<Position&, const Velocity&>();
-    EXPECT_TRUE(are_dependencies_overlapping(audio_sig, physics_sig));
-    EXPECT_TRUE(are_dependencies_overlapping(ui_sig, physics_sig));
-    EXPECT_TRUE(are_dependencies_overlapping(logger_sig, physics_sig));
-}
-
-TEST_F(HephaestusUtilsTest, HasDuplicateComponentTypeDetection) {
+TEST(HephaestusTest, HasDuplicateComponentTypeDetection) {
     EXPECT_FALSE((HAS_DUPLICATE_COMPONENT_TYPE_V<>));
     EXPECT_FALSE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position>));
     EXPECT_FALSE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position, Velocity>));
     EXPECT_FALSE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position, Velocity, Health>));
 
-    // Test cases with duplicates
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position, Position>));
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position, Velocity, Position>));
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position, Velocity, Health, Position>));
 
-    // Test with const variants (should still detect as duplicates)
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position&, const Position&>));
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position, Position&>));
 
-    // Test with references and cv-qualifiers
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position&, Position&>));
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<const Position&, Position&, Velocity>));
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<const Position, Position>));
 
-    // Multiple duplicates in one list
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<Position, Velocity, Position, Health, Velocity>));
 
-    // Non-component types (to ensure it works with any types)
     EXPECT_FALSE((HAS_DUPLICATE_COMPONENT_TYPE_V<int, float, double>));
     EXPECT_TRUE((HAS_DUPLICATE_COMPONENT_TYPE_V<int, float, int>));
 }
 
-// Integration test that actually runs the engine
-TEST(HephaestusIntegrationTest, ActualSystemCreationAndExecution) {
-    // Set up test state
+TEST(HephaestusTest, ActualSystemCreationAndExecution) {
+    USE_SHOULD_STOP = false;
     TestState state;
     TEST_STATE = &state;
 
-    // Create and run engine
-    Engine<TestGame> engine;
+    Engine<MockGame> engine;
     engine.run();
 
-    // Verify systems actually executed
-    // Each system should run once per frame for each matching entity
-    // Physics and renderer systems match 2 entities (both have Position+Velocity)
-    // Health checker matches 1 entity (only one has Health)
-    // With 3 frames: physics=6, renderer=6, health=3
     EXPECT_GT(state.physics_runs, 0) << "Physics system should have run";
     EXPECT_GT(state.renderer_runs, 0) << "Renderer system should have run";
     EXPECT_GT(state.health_checker_runs, 0) << "Health checker should have run";
 
-    // Clean up
     TEST_STATE = nullptr;
 }
 
-// Test class for the optimized signature system
-class HephaestusOptimizedSignatureTest : public ::testing::Test {
-  protected:
-    void SetUp() override {}
-    void TearDown() override {}
-};
-
-TEST_F(HephaestusOptimizedSignatureTest, ArchetypeKeyGeneration) {
-    // Test single component signature
+TEST(HephaestusTest, ArchetypeKeyGeneration) {
     auto pos_sig = make_archetype_key<Position>();
     auto vel_sig = make_archetype_key<Velocity>();
     auto health_sig = make_archetype_key<Health>();
+    auto empty_type = make_archetype_key<>();
 
-    // Signatures should be different
+    EXPECT_TRUE(empty_type.empty());
     EXPECT_NE(pos_sig, vel_sig);
     EXPECT_NE(vel_sig, health_sig);
     EXPECT_NE(pos_sig, health_sig);
 
-    // Test multiple component signature
     auto pos_vel_sig = make_archetype_key<Position, Velocity>();
     auto vel_health_sig = make_archetype_key<Velocity, Health>();
 
-    // Combined signatures should be different from individual ones
     EXPECT_NE(pos_vel_sig, pos_sig);
     EXPECT_NE(pos_vel_sig, vel_sig);
     EXPECT_NE(vel_health_sig, vel_sig);
     EXPECT_NE(vel_health_sig, health_sig);
 
-    // Combined signatures should be different from each other
     EXPECT_NE(pos_vel_sig, vel_health_sig);
 }
 
-TEST_F(HephaestusOptimizedSignatureTest, ArchetypeKeyOperations) {
+TEST(HephaestusTest, ArchetypeKeyOperations) {
     auto pos_sig = make_archetype_key<Position>();
     auto vel_sig = make_archetype_key<Velocity>();
     auto pos_vel_sig = make_archetype_key<Position, Velocity>();
 
-    // Test subset relationships
     EXPECT_TRUE(pos_sig.is_subset_of(pos_vel_sig));
     EXPECT_TRUE(vel_sig.is_subset_of(pos_vel_sig));
     EXPECT_FALSE(pos_vel_sig.is_subset_of(pos_sig));
     EXPECT_FALSE(pos_vel_sig.is_subset_of(vel_sig));
 
-    // Test intersections
     EXPECT_TRUE(pos_sig.intersects_with(pos_vel_sig));
     EXPECT_TRUE(vel_sig.intersects_with(pos_vel_sig));
     EXPECT_FALSE(pos_sig.intersects_with(vel_sig));
 
-    // Test component counting
     EXPECT_EQ(pos_sig.count_components(), 1);
     EXPECT_EQ(vel_sig.count_components(), 1);
     EXPECT_EQ(pos_vel_sig.count_components(), 2);
 }
 
-TEST_F(HephaestusOptimizedSignatureTest, ArchetypeKeyConsistency) {
-    // Test that order doesn't matter for signature generation
+TEST(HephaestusTest, ArchetypeKeyConsistency) {
     auto sig1 = make_archetype_key<Position, Velocity>();
     auto sig2 = make_archetype_key<Velocity, Position>();
 
     EXPECT_EQ(sig1, sig2) << "Archetype key should be order-independent";
 
-    // Test that const/non-const doesn't affect signature
     auto sig3 = make_archetype_key<const Position, Velocity>();
     auto sig4 = make_archetype_key<Position, const Velocity>();
     auto sig5 = make_archetype_key<const Position, const Velocity>();
@@ -323,27 +275,23 @@ TEST_F(HephaestusOptimizedSignatureTest, ArchetypeKeyConsistency) {
     EXPECT_EQ(sig1, sig5) << "const qualifiers should not affect archetype key";
 }
 
-TEST_F(HephaestusOptimizedSignatureTest, ArchetypeKeyHashPerformance) {
-    // Test that signature hashing is consistent
+TEST(HephaestusTest, ArchetypeKeyHash) {
     auto sig1 = make_archetype_key<Position, Velocity>();
     auto sig2 = make_archetype_key<Position, Velocity>();
 
     ArchetypeKeyHash hasher;
     EXPECT_EQ(hasher(sig1), hasher(sig2)) << "Equal keys should have equal hashes";
 
-    // Test that different signatures have different hashes (basic collision test)
     auto sig3 = make_archetype_key<Position, Health>();
     EXPECT_NE(hasher(sig1), hasher(sig3)) << "Different keys should have different hashes";
 }
 
-TEST_F(HephaestusOptimizedSignatureTest, ArchetypeMapCompatibility) {
-    // Test that ArchetypeMap can be created and used
+TEST(HephaestusTest, ArchetypeMapCompatibility) {
     ArchetypeMap map;
 
     auto sig1 = make_archetype_key<Position>();
     auto sig2 = make_archetype_key<Position, Velocity>();
 
-    // Test insertion and lookup
     map[sig1] = std::make_unique<Archetype>();
     map[sig2] = std::make_unique<Archetype>();
 
@@ -351,17 +299,15 @@ TEST_F(HephaestusOptimizedSignatureTest, ArchetypeMapCompatibility) {
     EXPECT_TRUE(map.contains(sig1));
     EXPECT_TRUE(map.contains(sig2));
 
-    // Test that different signatures map to different entries
     auto sig3 = make_archetype_key<Health>();
     EXPECT_FALSE(map.contains(sig3));
 }
 
-TEST_F(HephaestusOptimizedSignatureTest, PerformanceComparison) {
+TEST(HephaestusTest, PerformanceComparison) {
     using namespace std::chrono;
 
     const auto num_iterations = 10000;
 
-    // Test signature creation and hashing performance
     auto start_test = high_resolution_clock::now();
     ArchetypeKeyHash hasher;
     for (int i = 0; i < num_iterations; ++i) {
@@ -376,10 +322,8 @@ TEST_F(HephaestusOptimizedSignatureTest, PerformanceComparison) {
               << num_iterations << " iterations\n";
 
     // Verify performance is reasonable (should complete in well under a second)
-    EXPECT_LT(test_duration.count(), 1000000) // Less than 1 second
-        << "ArchetypeKey operations should be fast";
+    EXPECT_LT(test_duration.count(), 1000000) << "ArchetypeKey operations should be fast";
 
-    // Test signature operations performance
     auto sig1 = make_archetype_key<Position, Velocity>();
     auto sig2 = make_archetype_key<Position, Health>();
 
@@ -403,72 +347,83 @@ TEST_F(HephaestusOptimizedSignatureTest, PerformanceComparison) {
         << "ArchetypeKey operations should be constant time and very fast";
 }
 
-TEST_F(HephaestusOptimizedSignatureTest, MemoryFootprintComparison) {
-    // Test memory footprint of the new ArchetypeKey system
+TEST(HephaestusTest, MemoryFootprintComparison) {
     auto signature = make_archetype_key<Position, Velocity, Health>();
 
-    // The new signature system uses a fixed-size array of uint64_t values
     std::size_t signature_size = sizeof(signature);
-
-    // For comparison, estimate what a vector-based signature would cost
-    // (3 type_index elements + vector overhead)
-    std::size_t estimated_vector_size = sizeof(std::vector<std::type_index>)
-                                        + (3 * sizeof(std::type_index));
-
     std::cout << "ArchetypeKey memory footprint: " << signature_size << " bytes\n";
-    std::cout << "Estimated vector-based signature: " << estimated_vector_size << " bytes\n";
 
-    // Verify that we have a reasonable memory footprint
     EXPECT_EQ(signature_size, sizeof(ArchetypeKey::StorageType))
         << "ArchetypeKey should only contain the storage array";
 
-    // Verify signature functionality
     EXPECT_EQ(signature.count_components(), 3);
     EXPECT_FALSE(signature.empty());
 }
 
-// Demonstration of complete drop-in replacement
-TEST_F(HephaestusOptimizedSignatureTest, DropInReplacementDemo) {
-    // This test demonstrates how the optimized system could be used as a complete drop-in
-    // replacement In a real integration, you would include "hephaestus/OptimizedECS.hpp" instead of
-    // the legacy headers
+TEST(HephaestusTest, DeletingEntities) {
+    class TestGameDelete : public MockGame {
+      public:
+        auto pre_start() -> void override {
+            auto& hephaestus = get_engine().get_module<Hephaestus>().get();
+            hephaestus.create_system(
+                [this](const IEngine& engine, std::tuple<const Position&, const Health&> data) {
+                    flip_flop = !flip_flop;
+                }
+            );
+        }
 
-    // Create optimized archetype map
-    ArchetypeMap optimized_archetypes;
+        auto post_start() -> void override {
+            auto& hephaestus = get_engine().get_module<Hephaestus>().get();
+            EXPECT_EQ(hephaestus.get_tot_num_created_ents(), 0)
+                << "Hephaestus should not have created any entities yet.";
 
-    // Use the optimized signature generation
-    auto key = make_archetype_key<Position, Velocity>();
+            EXPECT_FALSE(flip_flop)
+                << "Should not have run any system yet, flip_flop should be false.";
 
-    // Add archetype to the map
-    optimized_archetypes[key] = std::make_unique<Archetype>();
+            hephaestus.tick();
 
-    // Test lookup performance
-    EXPECT_TRUE(optimized_archetypes.contains(key));
-    EXPECT_EQ(optimized_archetypes.size(), 1);
+            EXPECT_EQ(hephaestus.get_tot_num_created_ents(), 3)
+                << "After running a single tick hephaestus shouldve created all three entities.";
+            EXPECT_EQ(hephaestus.get_tot_num_destroyed_ents(), 0)
+                << "We should not have destroyed any entities at this point yet.";
+            EXPECT_TRUE(flip_flop) << "After running hephaestus.tick() flip_flop should be "
+                                      "true after running a system update.";
 
-    // Add more entities with different signatures
-    auto health_key = make_archetype_key<Position, Health>();
-    auto full_key = make_archetype_key<Position, Velocity, Health>();
+            hephaestus.destroy_entity(2);
+            EXPECT_EQ(
+                hephaestus.get_tot_num_destroyed_ents(),
+                0
+            ) << "We have called destroy_entity, but since its batched into end of frame (and this "
+                 "is outside of tick) it should not have destroyed anything yet, only queued it.";
 
-    optimized_archetypes[health_key] = std::make_unique<Archetype>();
-    optimized_archetypes[full_key] = std::make_unique<Archetype>();
+            hephaestus.tick();
+            EXPECT_EQ(hephaestus.get_tot_num_destroyed_ents(), 1)
+                << "After running tick again we shouldve deleted the entity.";
+            EXPECT_FALSE(flip_flop) << "Flip flop shouldve change value with this tick as well.";
 
-    EXPECT_EQ(optimized_archetypes.size(), 3);
-    EXPECT_TRUE(optimized_archetypes.contains(health_key));
-    EXPECT_TRUE(optimized_archetypes.contains(full_key));
+            hephaestus.tick();
+            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed the "
+                                       "the only entity for the system that updates it.";
+            hephaestus.tick();
+            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed the "
+                                       "the only entity for the system that updates it.";
+            hephaestus.tick();
+            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed the "
+                                       "the only entity for the system that updates it.";
 
-    // Demonstrate signature operations
-    EXPECT_TRUE(key.is_subset_of(full_key));
-    EXPECT_TRUE(health_key.is_subset_of(full_key));
-    EXPECT_TRUE(key.intersects_with(full_key));
-    EXPECT_TRUE(key.intersects_with(health_key)); // Both have Position component
+            EXPECT_EQ(hephaestus.get_tot_num_destroyed_ents(), 1)
+                << "Should have destroyed 1 entity";
 
-    // Test signatures that don't intersect
-    auto velocity_only = make_archetype_key<Velocity>();
-    auto health_only = make_archetype_key<Health>();
-    EXPECT_FALSE(velocity_only.intersects_with(health_only)); // No shared components
+            stop_game();
+        }
 
-    std::cout << "Drop-in replacement demo: Successfully managed " << optimized_archetypes.size()
-              << " archetypes with optimized signatures\n";
+      private:
+        // Not thread safe but fine since we only have one entity for this.
+        bool flip_flop = false;
+    };
+
+    USE_SHOULD_STOP = true;
+    Engine<TestGameDelete> engine;
+    engine.run();
 }
 } // namespace atlas::hephauestus::test

--- a/tests/HephaestusTests.cpp
+++ b/tests/HephaestusTests.cpp
@@ -402,13 +402,13 @@ TEST(HephaestusTest, DeletingEntities) {
             EXPECT_FALSE(flip_flop) << "Flip flop shouldve change value with this tick as well.";
 
             hephaestus.tick();
-            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed the "
+            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed "
                                        "the only entity for the system that updates it.";
             hephaestus.tick();
-            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed the "
+            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed "
                                        "the only entity for the system that updates it.";
             hephaestus.tick();
-            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed the "
+            EXPECT_FALSE(flip_flop) << "Flip flop should not change anymore. We destroyed "
                                        "the only entity for the system that updates it.";
 
             EXPECT_EQ(hephaestus.get_tot_num_destroyed_ents(), 1)

--- a/tests/HephaestusTests.cpp
+++ b/tests/HephaestusTests.cpp
@@ -408,12 +408,12 @@ TEST_F(HephaestusOptimizedSignatureTest, MemoryFootprintComparison) {
     auto signature = make_archetype_key<Position, Velocity, Health>();
 
     // The new signature system uses a fixed-size array of uint64_t values
-    size_t signature_size = sizeof(signature);
+    std::size_t signature_size = sizeof(signature);
 
     // For comparison, estimate what a vector-based signature would cost
     // (3 type_index elements + vector overhead)
-    size_t estimated_vector_size = sizeof(std::vector<std::type_index>)
-                                   + (3 * sizeof(std::type_index));
+    std::size_t estimated_vector_size = sizeof(std::vector<std::type_index>)
+                                        + (3 * sizeof(std::type_index));
 
     std::cout << "ArchetypeKey memory footprint: " << signature_size << " bytes\n";
     std::cout << "Estimated vector-based signature: " << estimated_vector_size << " bytes\n";


### PR DESCRIPTION
Optimize Archetype hashing/accessing. Add a O(1) access from Entity to Components via [ Entity -> ArchetypeKey | ArchetypeKey -> Archetype | Archetype (with Entity ID) -> Components ].

Add API for destroying entities. They get put in to a destroy queue and then batch destroyed at the end of each frame.