### PR TITLE
fix: Fix incorrect return type differing between declaration and

### DIFF
--- a/modules/hephaestus/src/hephaestus/Hephaestus.cpp
+++ b/modules/hephaestus/src/hephaestus/Hephaestus.cpp
@@ -147,11 +147,11 @@ auto Hephaestus::destroy_entity(Entity entity) -> void {
     destroy_queue.emplace_back(entity);
 }
 
-auto Hephaestus::get_tot_num_created_ents() const -> std::size_t {
+auto Hephaestus::get_tot_num_created_ents() const -> std::uint64_t {
     return tot_num_created_ents;
 }
 
-auto Hephaestus::get_tot_num_destroyed_ents() const -> std::size_t {
+auto Hephaestus::get_tot_num_destroyed_ents() const -> std::uint64_t {
     return tot_num_destroyed_ents;
 }
 } // namespace atlas::hephaestus


### PR DESCRIPTION
definition of get_tot_num_created_ents & get_tot_num_destroyed_ents: std::size_t -> std::uint64_t