### PR TITLE
fix: Error handling when dereferencing std::expected from `clock.get_total_time_without_first_frame()`.

### DIFF
--- a/include/atlas/core/Engine.hpp
+++ b/include/atlas/core/Engine.hpp
@@ -102,15 +102,18 @@ auto Engine<G>::run() -> void {
     }
 
     const auto total_time = clock.get_total_time();
-    const auto total_tick_time = *clock.get_total_time_without_first_frame();
+    std::println("--------------------");
     std::println("\nNum frames: {}", num_frames);
-    std::println("Total runtime: {}", total_time);
-    std::println("First frame: {}", total_time - total_tick_time);
+    std::println("Total runtime: {}\n", total_time);
 
-    std::println(
-        "\navg FPS(excluding first frame): {}",
-        static_cast<double>(num_frames) / total_tick_time
-    );
+    if (const auto total_tick_time = clock.get_total_time_without_first_frame();
+        total_tick_time.has_value()) {
+        std::println("First frame: {}\n", total_time - *total_tick_time);
+        std::println(
+            "avg FPS(excluding first frame): {}",
+            static_cast<double>(num_frames) / *total_tick_time
+        );
+    }
     std::println("avg FPS: {}", static_cast<double>(num_frames) / total_time);
 
     std::println("\navg frame time: {} ms", clock.get_avg_frame_time() * 1000);

--- a/include/atlas/core/IEngine.hpp
+++ b/include/atlas/core/IEngine.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <typeindex>
 
 #include "Concepts.hpp"


### PR DESCRIPTION
 It throws errors when running tests without full engine ticks on MSVC.